### PR TITLE
Default changing all projects assembly version

### DIFF
--- a/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
+++ b/src/main/groovy/com/ullink/AssemblyInfoVersionPatcher.groovy
@@ -13,7 +13,7 @@ class AssemblyInfoVersionPatcher extends ConventionTask {
     List<String> projects = []
 
     AssemblyInfoVersionPatcher() {
-        conventionMapping.map "projects", { [ project.tasks.msbuild.mainProject?.projectName ] }
+        conventionMapping.map "projects", { project.tasks.msbuild.projects.collect { it.name } }
         conventionMapping.map "files", {
             getProjects()
                 .collect { project.tasks.msbuild.projects[it] }


### PR DESCRIPTION
Changing the default of AssemblyInfoVersionPatcher to patch all projects under the same solution to the desired version instead of only the main project
